### PR TITLE
Editor Suggestion loses part of text string when changing part of it (LEAN-2430)

### DIFF
--- a/.changeset/tough-mirrors-sort.md
+++ b/.changeset/tough-mirrors-sort.md
@@ -1,0 +1,5 @@
+---
+'@manuscripts/track-changes-plugin': minor
+---
+
+LEAN-2430

--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.3.1",
+  "version": "1.3.1-LEAN-1697",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",

--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.3.1-LEAN-1697",
+  "version": "1.3.1-LEAN-2430",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",

--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",

--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",

--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.3.1-LEAN-2430",
+  "version": "1.3.1",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -104,7 +104,7 @@ export function processChangeSteps(
         return
       }
       mergeTrackedMarks(mapping.map(c.from), newTr.doc, newTr, schema)
-      mergeTrackedMarks(mapping.map(c.to), newTr.doc, newTr, schema)
+      mergeTrackedMarks(mapping.map(c.to + 1), newTr.doc, newTr, schema)
       selectionPos = mapping.map(c.to) + c.slice.size
     } else if (c.type === 'update-node-attrs') {
       const oldDataTracked = getBlockInlineTrackedData(c.node) || []

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -56,7 +56,7 @@ export function processChangeSteps(
         log.error(`processChangeSteps: no text node found for text-change`, c)
         return
       }
-      const where = deleteTextIfInserted(
+      deleteTextIfInserted(
         node,
         mapping.map(c.pos),
         newTr,
@@ -65,7 +65,6 @@ export function processChangeSteps(
         mapping.map(c.from),
         mapping.map(c.to)
       )
-      mergeTrackedMarks(where, newTr.doc, newTr, schema)
     } else if (c.type === 'merge-fragment') {
       let insertPos = mapping.map(c.mergePos)
       // The default insert position for block nodes is either the start of the merged content or the end.
@@ -104,7 +103,7 @@ export function processChangeSteps(
         return
       }
       mergeTrackedMarks(mapping.map(c.from), newTr.doc, newTr, schema)
-      mergeTrackedMarks(mapping.map(c.to + 1), newTr.doc, newTr, schema)
+      mergeTrackedMarks(mapping.map(c.to) + c.slice.size, newTr.doc, newTr, schema)
       selectionPos = mapping.map(c.to) + c.slice.size
     } else if (c.type === 'update-node-attrs') {
       const oldDataTracked = getBlockInlineTrackedData(c.node) || []

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -104,7 +104,7 @@ export function processChangeSteps(
         return
       }
       mergeTrackedMarks(mapping.map(c.from), newTr.doc, newTr, schema)
-      mergeTrackedMarks(mapping.map(c.to) + c.slice.size, newTr.doc, newTr, schema)
+      mergeTrackedMarks(mapping.map(c.to) + (newTr.doc.nodeSize < c.slice.size ? newTr.doc.nodeSize : 0), newTr.doc, newTr, schema)
       selectionPos = mapping.map(c.to) + c.slice.size
     } else if (c.type === 'update-node-attrs') {
       const oldDataTracked = getBlockInlineTrackedData(c.node) || []

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -104,7 +104,8 @@ export function processChangeSteps(
         return
       }
       mergeTrackedMarks(mapping.map(c.from), newTr.doc, newTr, schema)
-      mergeTrackedMarks(mapping.map(c.to) + (newTr.doc.nodeSize < c.slice.size ? c.slice.size : 0), newTr.doc, newTr, schema)
+      const to = mapping.map(c.to) + c.slice.size
+      mergeTrackedMarks(mapping.map(c.to) + (to < newTr.doc.nodeSize ? c.slice.size : 0), newTr.doc, newTr, schema)
       selectionPos = mapping.map(c.to) + c.slice.size
     } else if (c.type === 'update-node-attrs') {
       const oldDataTracked = getBlockInlineTrackedData(c.node) || []

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -56,7 +56,7 @@ export function processChangeSteps(
         log.error(`processChangeSteps: no text node found for text-change`, c)
         return
       }
-      deleteTextIfInserted(
+      const where = deleteTextIfInserted(
         node,
         mapping.map(c.pos),
         newTr,
@@ -65,6 +65,7 @@ export function processChangeSteps(
         mapping.map(c.from),
         mapping.map(c.to)
       )
+      mergeTrackedMarks(where, newTr.doc, newTr, schema)
     } else if (c.type === 'merge-fragment') {
       let insertPos = mapping.map(c.mergePos)
       // The default insert position for block nodes is either the start of the merged content or the end.

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -104,7 +104,7 @@ export function processChangeSteps(
         return
       }
       mergeTrackedMarks(mapping.map(c.from), newTr.doc, newTr, schema)
-      mergeTrackedMarks(mapping.map(c.to) + (newTr.doc.nodeSize < c.slice.size ? newTr.doc.nodeSize : 0), newTr.doc, newTr, schema)
+      mergeTrackedMarks(mapping.map(c.to) + (newTr.doc.nodeSize < c.slice.size ? c.slice.size : 0), newTr.doc, newTr, schema)
       selectionPos = mapping.map(c.to) + c.slice.size
     } else if (c.type === 'update-node-attrs') {
       const oldDataTracked = getBlockInlineTrackedData(c.node) || []


### PR DESCRIPTION
The issue here in the second call for [mergeTrackedMarks](https://github.com/Atypon-OpenSource/manuscripts-quarterback/blob/e099b62ed9e1303e40fc6dee9c10866728e2b41c/quarterback-packages/track-changes-plugin/src/mutate/mergeTrackedMarks.ts#L35) we need to increase the `c.to` postion so we get the right `nodeAfter, nodeBefore` nodes