### PR TITLE
Track References Node (LEAN-2723)

### DIFF
--- a/quarterback-packages/track-changes-plugin/package.json
+++ b/quarterback-packages/track-changes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.6.1",
+  "version": "1.6.1-LEAN-2723",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-quarterback/tree/main/quarterback-packages/track-changes-plugin",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@manuscripts/data": "^1.0.2",
     "@manuscripts/json-schema": "^2.0.2",
-    "@manuscripts/transform": "^1.2.5",
+    "@manuscripts/transform": "1.3.11-LEAN-2723",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@types/debug": "^4.1.7",
     "@types/jest": "27.5.1",

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -23,7 +23,7 @@ import { ChangeStep } from '../types/step'
 import { NewEmptyAttrs } from '../types/track'
 import { deleteOrSetNodeDeleted } from '../mutate/deleteNode'
 import { deleteTextIfInserted } from '../mutate/deleteText'
-import { mergeTrackedMarks } from '../mutate/mergeTrackedMarks'
+import { addMarkToBlockNode, mergeTrackedMarks } from '../mutate/mergeTrackedMarks'
 import { addTrackIdIfDoesntExist, getBlockInlineTrackedData } from '../compute/nodeHelpers'
 import * as trackUtils from '../utils/track-utils'
 
@@ -49,7 +49,8 @@ export function processChangeSteps(
         mapping.appendMap(newestStep.getMap())
         step = newestStep
       }
-      mergeTrackedMarks(mapping.map(c.pos), newTr.doc, newTr, schema)
+      //  TODO: create a test case
+      addMarkToBlockNode(c.pos, c.node, newTr, deleteAttrs, schema)
     } else if (c.type === 'delete-text') {
       const node = newTr.doc.nodeAt(mapping.map(c.pos))
       if (!node) {

--- a/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
+++ b/quarterback-packages/track-changes-plugin/src/change-steps/processChangeSteps.ts
@@ -49,7 +49,6 @@ export function processChangeSteps(
         mapping.appendMap(newestStep.getMap())
         step = newestStep
       }
-      //  TODO: create a test case
       addMarkToBlockNode(c.pos, c.node, newTr, deleteAttrs, schema)
     } else if (c.type === 'delete-text') {
       const node = newTr.doc.nodeAt(mapping.map(c.pos))

--- a/quarterback-packages/track-changes-plugin/src/changes/applyChanges.ts
+++ b/quarterback-packages/track-changes-plugin/src/changes/applyChanges.ts
@@ -61,6 +61,8 @@ export function applyAcceptedRejectedChanges(
       const attrs = { ...node.attrs, dataTracked: null }
       tr.setNodeMarkup(from, undefined, attrs, node.marks)
       updateChangeChildrenAttributes(change.children, tr, deleteMap)
+      tr.removeNodeMark(from, schema.marks.tracked_insert)
+      tr.removeNodeMark(from, schema.marks.tracked_delete)
     } else if (ChangeSet.isNodeChange(change)) {
       // Try first moving the node children to either nodeAbove, nodeBelow or its parent.
       // Then try unwrapping it with lift or just hacky-joining by replacing the border between

--- a/quarterback-packages/track-changes-plugin/src/compute/setFragmentAsInserted.ts
+++ b/quarterback-packages/track-changes-plugin/src/compute/setFragmentAsInserted.ts
@@ -20,6 +20,22 @@ import { CHANGE_OPERATION } from '../types/change'
 import { NewInsertAttrs, NewTrackedAttrs } from '../types/track'
 import { addTrackIdIfDoesntExist, equalMarks, getTextNodeTrackedMarkData } from './nodeHelpers'
 
+function getBlockNodeMark(node: PMNode, newTrackAttrs: NewTrackedAttrs, schema: Schema) {
+  if (node.type === schema.nodes.bibliography_item) {
+    const mark =
+      newTrackAttrs.operation === CHANGE_OPERATION.insert
+        ? schema.marks.tracked_insert
+        : schema.marks.tracked_delete
+    return [
+      mark.create({
+        isBlock: node.isBlock,
+        dataTracked: addTrackIdIfDoesntExist(newTrackAttrs),
+      }),
+    ]
+  }
+  return node.marks
+}
+
 function markInlineNodeChange(node: PMNode, newTrackAttrs: NewTrackedAttrs, schema: Schema) {
   const filtered = node.marks.filter(
     (m) => m.type !== schema.marks.tracked_insert && m.type !== schema.marks.tracked_delete
@@ -78,7 +94,7 @@ function recurseNodeContent(node: PMNode, newTrackAttrs: NewTrackedAttrs, schema
         dataTracked: [addTrackIdIfDoesntExist(newTrackAttrs)],
       },
       Fragment.fromArray(updatedChildren),
-      node.marks
+      getBlockNodeMark(node, newTrackAttrs, schema)
     )
   } else {
     log.error(`unhandled node type: "${node.type.name}"`, node)

--- a/quarterback-packages/track-changes-plugin/src/mutate/mergeTrackedMarks.ts
+++ b/quarterback-packages/track-changes-plugin/src/mutate/mergeTrackedMarks.ts
@@ -18,6 +18,7 @@ import type { Transaction } from 'prosemirror-state'
 
 import { shouldMergeTrackedAttributes } from '../compute/nodeHelpers'
 import type { TrackedAttrs } from '../types/change'
+import {NewDeleteAttrs} from "../types/track";
 
 /**
  * Merges tracked marks between text nodes at a position
@@ -61,4 +62,26 @@ export function mergeTrackedMarks(pos: number, doc: PMNode, newTr: Transaction, 
     toEndOfMark,
     leftMark.type.create({ ...leftMark.attrs, dataTracked })
   )
+}
+
+/** This will be just for the bibliography_item and citation as for other block nodes we need to update
+ *  there marks in the schema.
+ *  and for figure, table, sections, paragraph we add marks just to the inline text inside of them
+ **/
+export function addMarkToBlockNode(
+  pos: number,
+  node: PMNode,
+  newTr: Transaction,
+  deleteAttrs: NewDeleteAttrs,
+  schema: Schema
+) {
+  if (node.type === schema.nodes.bibliography_item || node.type === schema.nodes.citation) {
+    newTr.addNodeMark(
+      pos,
+      schema.marks.tracked_delete.create({
+        isBlock: node.isBlock,
+        dataTracked: { deleteAttrs },
+      })
+    )
+  }
 }

--- a/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-items-updated.json
+++ b/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-items-updated.json
@@ -1,0 +1,152 @@
+{
+  "type": "manuscript",
+  "attrs": {
+    "id": "MPManuscript:A05A2501-8BE3-44C8-AA30-B148444FDC18"
+  },
+  "content": [
+    {
+      "type": "bibliography_section",
+      "attrs": {
+        "id": "MPSection:07686627-C659-4EAE-8ED5-6A4E30116D6B",
+        "dataTracked": null
+      },
+      "content": [
+        {
+          "type": "section_title",
+          "attrs": {
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "REFERENCES"
+            }
+          ]
+        },
+        {
+          "type": "bibliography_element",
+          "attrs": {
+            "id": "MPBibliographyElement:F186E678-952E-4733-87EB-93CA74D89E41",
+            "contents": "",
+            "paragraphStyle": "",
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "bibliography_item",
+              "attrs": {
+                "id": "MPBibliographyItem:01E85B21-64E0-4816-BA36-6BFA1466A584",
+                "type": "article-journal",
+                "author": [
+                  "Caldwell",
+                  "Gottesman"
+                ],
+                "issued": "1992",
+                "containerTitle": "Suicide Life Threat Behav.",
+                "volume": "22",
+                "issue": "4",
+                "page": "479-493",
+                "title": "Schizophrenia-a high-risk factor for suicide: clues to risk reduction.",
+                "paragraphStyle": "",
+                "dataTracked": [
+                  {
+                    "id": "MOCK-ID-0",
+                    "authorID": "1-mike",
+                    "reviewedByID": null,
+                    "createdAt": 1577836800000,
+                    "updatedAt": 1577836800000,
+                    "status": "pending",
+                    "operation": "delete"
+                  }
+                ]
+              },
+              "marks": [
+                {
+                  "type": "tracked_delete",
+                  "attrs": {
+                    "isBlock": true,
+                    "dataTracked": {
+                      "deleteAttrs": {
+                        "authorID": "1-mike",
+                        "reviewedByID": null,
+                        "createdAt": 1577836800000,
+                        "updatedAt": 1577836800000,
+                        "status": "pending",
+                        "operation": "delete"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "bibliography_item",
+              "attrs": {
+                "id": "MPBibliographyItem:3B49B4EB-39F5-4208-B5FE-A5CD6E0D9692",
+                "type": "article-journal",
+                "containerTitle": "Arthritis Research &amp; Therapy",
+                "doi": "10.1016/s0738-3991(02)00202-1",
+                "volume": "48",
+                "paragraphStyle": "",
+                "dataTracked": [
+                  {
+                    "id": "MOCK-ID-1",
+                    "authorID": "1-mike",
+                    "reviewedByID": null,
+                    "createdAt": 1577836800000,
+                    "updatedAt": 1577836800000,
+                    "status": "pending",
+                    "operation": "insert"
+                  }
+                ]
+              },
+              "marks": [
+                {
+                  "type": "tracked_insert",
+                  "attrs": {
+                    "isBlock": true,
+                    "dataTracked": {
+                      "id": "MOCK-ID-2",
+                      "authorID": "1-mike",
+                      "reviewedByID": null,
+                      "createdAt": 1577836800000,
+                      "updatedAt": 1577836800000,
+                      "status": "pending",
+                      "operation": "insert"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "meta_section",
+      "attrs": {
+        "id": "META_SECTION"
+      },
+      "content": [
+        {
+          "type": "affiliation_list",
+          "attrs": {
+            "id": "AFFILIATION_LIST"
+          }
+        },
+        {
+          "type": "contributor_list",
+          "attrs": {
+            "id": "CONTRIBUTOR_LIST"
+          }
+        },
+        {
+          "type": "comment_list",
+          "attrs": {
+            "id": "COMMENT_LIST"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-section.json
+++ b/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-section.json
@@ -1,0 +1,82 @@
+{
+  "attrs": {
+    "id": "MPManuscript:A05A2501-8BE3-44C8-AA30-B148444FDC18"
+  },
+  "type": "manuscript",
+  "content": [
+    {
+      "type": "bibliography_section",
+      "attrs": {
+        "id": "MPSection:07686627-C659-4EAE-8ED5-6A4E30116D6B",
+        "dataTracked": null
+      },
+      "content": [
+        {
+          "type": "section_title",
+          "attrs": {
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "REFERENCES"
+            }
+          ]
+        },
+        {
+          "type": "bibliography_element",
+          "attrs": {
+            "id": "MPBibliographyElement:F186E678-952E-4733-87EB-93CA74D89E41",
+            "contents": "",
+            "paragraphStyle": "",
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "bibliography_item",
+              "attrs": {
+                "id": "MPBibliographyItem:01E85B21-64E0-4816-BA36-6BFA1466A584",
+                "type": "article-journal",
+                "author": ["Caldwell","Gottesman"],
+                "issued": "1992",
+                "containerTitle": "Suicide Life Threat Behav.",
+                "volume": "22",
+                "issue": "4",
+                "page": "479-493",
+                "title": "Schizophrenia-a high-risk factor for suicide: clues to risk reduction.",
+                "paragraphStyle": "",
+                "dataTracked": null
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "meta_section",
+      "attrs": {
+        "id": "META_SECTION"
+      },
+      "content": [
+        {
+          "type": "affiliation_list",
+          "attrs": {
+            "id": "AFFILIATION_LIST"
+          }
+        },
+        {
+          "type": "contributor_list",
+          "attrs": {
+            "id": "CONTRIBUTOR_LIST"
+          }
+        },
+        {
+          "type": "comment_list",
+          "attrs": {
+            "id": "COMMENT_LIST"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/quarterback-packages/track-changes-plugin/test/__fixtures__/docs.ts
+++ b/quarterback-packages/track-changes-plugin/test/__fixtures__/docs.ts
@@ -15,6 +15,8 @@
  */
 import paragraph from './paragraph.json'
 import equation from './equation.json'
+import bibliographySection from './bibliography-section.json'
+import bibliographyUpdated from './bibliography-items-updated.json'
 import manuscriptSimple from './manuscript-simple.json'
 import manyParagraphs from './many-paragraphs.json'
 import blockquoteMarks from './blockquote-marks.json'
@@ -25,6 +27,8 @@ import table from './table.json'
 export default {
   paragraph,
   equation,
+  bibliographySection,
+  bibliographyUpdated,
   manyParagraphs,
   manuscriptSimple,
   blockquoteMarks,

--- a/quarterback-packages/track-changes-plugin/test/nodes/nodes.test.ts
+++ b/quarterback-packages/track-changes-plugin/test/nodes/nodes.test.ts
@@ -16,6 +16,7 @@
 /// <reference types="@types/jest" />;
 import { promises as fs } from 'fs'
 import { NodeSelection } from 'prosemirror-state'
+import { schema as manuscriptSchema } from '@manuscripts/transform'
 
 import { CHANGE_STATUS, trackChangesPluginKey, trackCommands, ChangeSet } from '../../src'
 import docs from '../__fixtures__/docs'
@@ -30,6 +31,7 @@ import blockNodeAttrUpdate from './block-node-attr-update.json'
 import inlineNodeAttrUpdate from './inline-node-attr-update.json'
 import wrapWithLink from './wrap-with-link.json'
 import tableDiff from './table-attr-update.json'
+import bibliographyUpdated from "../__fixtures__/bibliography-items-updated.json";
 
 let counter = 0
 // https://stackoverflow.com/questions/65554910/jest-referenceerror-cannot-access-before-initialization
@@ -200,6 +202,38 @@ describe('nodes.test', () => {
     expect(tester.toJSON()).toEqual(tableDiff[0])
     expect(uuidv4Mock.mock.calls.length).toBe(2)
     expect(tester.trackState()?.changeSet.hasInconsistentData).toEqual(false)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('should track insert & delete of bibliography item node with marks', async () => {
+    const tester = setupEditor({
+      doc: docs.bibliographySection,
+      schema: manuscriptSchema,
+    })
+
+    tester.cmd((state, dispatch) => {
+      dispatch(state.tr.delete(14, 15))
+    })
+
+    tester.cmd((state, dispatch) => {
+      dispatch(
+        state.tr.insert(
+          15,
+          manuscriptSchema.nodes.bibliography_item.create({
+            id: 'MPBibliographyItem:3B49B4EB-39F5-4208-B5FE-A5CD6E0D9692',
+            type: 'article-journal',
+            containerTitle: 'Arthritis Research &amp; Therapy',
+            doi: '10.1016/s0738-3991(02)00202-1',
+            volume: '48',
+          })
+        )
+      )
+    })
+
+    expect(tester.toJSON().doc).toEqual(docs.bibliographyUpdated)
+    expect(tester.trackState()?.changeSet.hasInconsistentData).toEqual(false)
+    expect(uuidv4Mock.mock.calls.length).toBe(3)
     expect(log.warn).toHaveBeenCalledTimes(0)
     expect(log.error).toHaveBeenCalledTimes(0)
   })

--- a/quarterback-packages/track-changes-plugin/yarn.lock
+++ b/quarterback-packages/track-changes-plugin/yarn.lock
@@ -529,12 +529,20 @@
     ajv "^8.12.0"
     deepmerge "^4.3.1"
 
-"@manuscripts/transform@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@manuscripts/transform/-/transform-1.2.5.tgz#f5e1867992e58fba41fdb0a3c4f67f74ae855372"
-  integrity sha512-Oe/AdoGRNnTH/6jlZIstohUK6azK2gDugXw1Swgy54yVlPYwqpK+064NpdARXRVrwFyCcWXJt7tqbPvFh96dpA==
+"@manuscripts/json-schema@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@manuscripts/json-schema/-/json-schema-2.1.1.tgz#f37c0c059ade6c001bd4d789deddde293066cd80"
+  integrity sha512-ePFyoeOYymTZLjQAIjr1+DT6RnwKdJZ5dkEvwR7qTLeIlYEwXY1Ho8Xis8PXQz6pmw0QX5EvgjOhGFduZ7irqg==
   dependencies:
-    "@manuscripts/json-schema" "^2.0.2"
+    ajv "^8.12.0"
+    deepmerge "^4.3.1"
+
+"@manuscripts/transform@1.3.11-LEAN-2723":
+  version "1.3.11-LEAN-2723"
+  resolved "https://registry.yarnpkg.com/@manuscripts/transform/-/transform-1.3.11-LEAN-2723.tgz#f09eeb8face6716669a76b32a00826b33da4513a"
+  integrity sha512-ktPm8YHeEP0v0ryjASBwnGHyEx1CFEMqhDMKefTa0FFu5GOVEvvC58f672XwgflB3tVEhkRcO9kiGXL1bg149g==
+  dependencies:
+    "@manuscripts/json-schema" "^2.1.1"
     debug "^4.3.4"
     jszip "^3.10.1"
     mathjax-full "^3.2.2"


### PR DESCRIPTION
We need to track changes(insert, delete) on `bibliography_item` as a block node. The same will be for mark will use markNode as there is no text to add for it