### PR TITLE
REFTC-90 - Implementation (LEAN-2737)

### DIFF
--- a/quarterback-packages/track-changes-plugin/src/actions.ts
+++ b/quarterback-packages/track-changes-plugin/src/actions.ts
@@ -25,6 +25,7 @@ export enum TrackChangesAction {
   setChangeStatuses = 'track-changes-set-change-statuses',
   refreshChanges = 'track-changes-refresh-changes',
   applyAndRemoveChanges = 'track-changes-apply-remove-changes',
+  updateMetaNode = 'track-changes-update-meta-node',
 }
 
 export type TrackChangesActionParams = {
@@ -37,6 +38,7 @@ export type TrackChangesActionParams = {
   }
   [TrackChangesAction.refreshChanges]: boolean
   [TrackChangesAction.applyAndRemoveChanges]: boolean
+  [TrackChangesAction.updateMetaNode]: boolean
 }
 
 /**

--- a/quarterback-packages/track-changes-plugin/src/steps/trackTransaction.ts
+++ b/quarterback-packages/track-changes-plugin/src/steps/trackTransaction.ts
@@ -145,7 +145,7 @@ export function trackTransaction(
         newTr.setSelection(near)
       }
     } else if (step instanceof ReplaceAroundStep) {
-      let steps = trackReplaceAroundStep(step, oldState, newTr, emptyAttrs)
+      let steps = trackReplaceAroundStep(step, oldState, tr, newTr, emptyAttrs)
       const deleted = steps.filter((s) => s.type !== 'insert-slice')
       const inserted = steps.filter((s) => s.type === 'insert-slice') as InsertSliceStep[]
       log.info('INSERT STEPS: ', inserted)

--- a/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-section.json
+++ b/quarterback-packages/track-changes-plugin/test/__fixtures__/bibliography-section.json
@@ -1,0 +1,56 @@
+{
+  "attrs": {
+    "id": "MPManuscript:A05A2501-8BE3-44C8-AA30-B148444FDC18"
+  },
+  "type": "manuscript",
+  "content": [
+    {
+      "type": "bibliography_section",
+      "attrs": {
+        "id": "MPSection:07686627-C659-4EAE-8ED5-6A4E30116D6B",
+        "dataTracked": null
+      },
+      "content": [
+        {
+          "type": "section_title",
+          "attrs": {
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "REFERENCES"
+            }
+          ]
+        },
+        {
+          "type": "bibliography_element",
+          "attrs": {
+            "id": "MPBibliographyElement:F186E678-952E-4733-87EB-93CA74D89E41",
+            "contents": "",
+            "paragraphStyle": "",
+            "dataTracked": null
+          },
+          "content": [
+            {
+              "type": "bibliography_item",
+              "attrs": {
+                "id": "MPBibliographyItem:01E85B21-64E0-4816-BA36-6BFA1466A584",
+                "type": "article-journal",
+                "author": ["Caldwell","Gottesman"],
+                "issued": "1992",
+                "containerTitle": "Suicide Life Threat Behav.",
+                "volume": "22",
+                "issue": "4",
+                "page": "479-493",
+                "title": "Schizophrenia-a high-risk factor for suicide: clues to risk reduction.",
+                "paragraphStyle": "",
+                "dataTracked": null
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/quarterback-packages/track-changes-plugin/test/__fixtures__/docs.ts
+++ b/quarterback-packages/track-changes-plugin/test/__fixtures__/docs.ts
@@ -16,6 +16,7 @@
 import paragraph from './paragraph.json'
 import equation from './equation.json'
 import manuscriptSimple from './manuscript-simple.json'
+import bibliographySection from './bibliography-section.json'
 import manyParagraphs from './many-paragraphs.json'
 import blockquoteMarks from './blockquote-marks.json'
 import nestedBlockquotes from './nested-blockquotes.json'
@@ -25,6 +26,7 @@ import table from './table.json'
 export default {
   paragraph,
   equation,
+  bibliographySection,
   manyParagraphs,
   manuscriptSimple,
   blockquoteMarks,


### PR DESCRIPTION
This PR will fix the issue of considering the updated bibliography node as a deleted node. issue starts from this [check](https://github.com/Atypon-OpenSource/manuscripts-quarterback/blob/f74e8a4fbcdecc61f5fec13bcf6e3fb9e560b0be/quarterback-packages/track-changes-plugin/src/steps/trackReplaceAroundStep.ts#L84) for content to insert a slice, and as we know that node will be empty it just holds data in attributes, so to bypass this check will use metadata in the transaction in case of an update for the bibliography node to ignore check